### PR TITLE
Add subsampling

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -10,9 +10,22 @@ The directories listed below will be created in the results directory after the 
 
 The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes data using the following steps:
 
+- [seqkit](#seqkit) - Subsample a specific number of reads per sample
 - [FastQC](#fastqc) - Raw read QC
 - [MultiQC](#multiqc) - Aggregate report describing results and QC from the whole pipeline
 - [Pipeline information](#pipeline-information) - Report metrics generated during the workflow execution
+
+### Seqkit
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `seqtk/`
+  - `*_fastq`: FastQ file after being subsampled to the sample_size value.
+
+</details>
+
+[SeqKit](https://bioinf.shenwei.me/seqkit/) samples sequences by number. For further reading and documentation see the [FastQC help pages](https://bioinf.shenwei.me/seqkit/usage/#sample).
 
 ### FastQC
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -93,6 +93,11 @@ genome: 'GRCh37'
 
 You can also generate such `YAML`/`JSON` files via [nf-core/launch](https://nf-co.re/launch).
 
+Optionally, the `sample_size` parameter allows you to subset a random number of reads to be analysed.
+```bash
+nextflow run nf-core/seqinspector --input ./samplesheet.csv --outdir ./results --sample_size 90 -profile docker
+```
+
 ### Updating the pipeline
 
 When you run the above command, Nextflow automatically pulls the pipeline code from GitHub and stores it as a cached version. When running the pipeline after this, it will always use the cached version if available - even if the pipeline has been updated since. To make sure that you're running the latest version of the pipeline, make sure that you regularly update the cached version of the pipeline:

--- a/modules.json
+++ b/modules.json
@@ -14,6 +14,11 @@
                         "branch": "master",
                         "git_sha": "cf17ca47590cc578dfb47db1c2a44ef86f89976d",
                         "installed_by": ["modules"]
+                    },
+                    "seqtk/sample": {
+                        "branch": "master",
+                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "installed_by": ["modules"]
                     }
                 }
             },

--- a/modules/nf-core/seqtk/sample/environment.yml
+++ b/modules/nf-core/seqtk/sample/environment.yml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::seqtk=1.4

--- a/modules/nf-core/seqtk/sample/main.nf
+++ b/modules/nf-core/seqtk/sample/main.nf
@@ -1,0 +1,58 @@
+process SEQTK_SAMPLE {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/seqtk:1.4--he4a0461_1' :
+        'biocontainers/seqtk:1.4--he4a0461_1' }"
+
+    input:
+    tuple val(meta), path(reads), val(sample_size)
+
+    output:
+    tuple val(meta), path("*.fastq.gz"), emit: reads
+    path "versions.yml"                , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    if (!(args ==~ /.*-s[0-9]+.*/)) {
+        args += " -s100"
+    }
+    if ( !sample_size ) {
+        error "SEQTK/SAMPLE must have a sample_size value included"
+    }
+    """
+    printf "%s\\n" $reads | while read f;
+    do
+        seqtk \\
+            sample \\
+            $args \\
+            \$f \\
+            $sample_size \\
+            | gzip --no-name > ${prefix}_\$(basename \$f)
+    done
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqtk: \$(echo \$(seqtk 2>&1) | sed 's/^.*Version: //; s/ .*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    echo "" | gzip > ${prefix}.fastq.gz
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqtk: \$(echo \$(seqtk 2>&1) | sed 's/^.*Version: //; s/ .*\$//')
+    END_VERSIONS
+    """
+
+}

--- a/modules/nf-core/seqtk/sample/meta.yml
+++ b/modules/nf-core/seqtk/sample/meta.yml
@@ -1,0 +1,52 @@
+name: seqtk_sample
+description: Subsample reads from FASTQ files
+keywords:
+  - sample
+  - fastx
+  - reads
+tools:
+  - seqtk:
+      description: Seqtk is a fast and lightweight tool for processing sequences in
+        the FASTA or FASTQ format. Seqtk sample command subsamples sequences.
+      homepage: https://github.com/lh3/seqtk
+      documentation: https://docs.csc.fi/apps/seqtk/
+      tool_dev_url: https://github.com/lh3/seqtk
+      licence: ["MIT"]
+      identifier: biotools:seqtk
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: List of input FastQ files
+        pattern: "*.{fastq.gz}"
+    - sample_size:
+        type: integer
+        description: Number of reads to sample.
+output:
+  - reads:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fastq.gz":
+          type: file
+          description: Subsampled FastQ files
+          pattern: "*.{fastq.gz}"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+authors:
+  - "@kaurravneet4123"
+  - "@sidorov-si"
+  - "@adamrtalbot"
+maintainers:
+  - "@kaurravneet4123"
+  - "@sidorov-si"
+  - "@adamrtalbot"

--- a/modules/nf-core/seqtk/sample/tests/main.nf.test
+++ b/modules/nf-core/seqtk/sample/tests/main.nf.test
@@ -1,0 +1,80 @@
+nextflow_process {
+
+    name "Test Process SEQTK_SAMPLE"
+    script "modules/nf-core/seqtk/sample/main.nf"
+    process "SEQTK_SAMPLE"
+    config "./standard.config"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "seqtk"
+    tag "seqtk/sample"
+
+    test("sarscov2_sample_singleend_fqgz") {
+
+        when {
+            process {
+                """
+                input[0] =  [
+                                [ id:'test', single_end:true ],
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                                50
+                            ]
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2_sample_pairedend_fqgz") {
+
+        when {
+            process {
+                """
+                input[0] =  [
+                                [ id:'test', single_end:true ],
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                                50
+                            ]
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2_sample_singlend_fqgz_stub") {
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] =  [
+                                [ id:'test', single_end:true ],
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                                50
+                            ]
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/seqtk/sample/tests/main.nf.test.snap
+++ b/modules/nf-core/seqtk/sample/tests/main.nf.test.snap
@@ -1,0 +1,95 @@
+{
+    "sarscov2_sample_singlend_fqgz_stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.sampled.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,0529f2d163df9e2cd2ae8254dfb63806"
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.sampled.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,0529f2d163df9e2cd2ae8254dfb63806"
+                ]
+            }
+        ],
+        "timestamp": "2024-02-22T15:58:45.902956"
+    },
+    "sarscov2_sample_pairedend_fqgz": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.sampled_test_1.fastq.gz:md5,e5f44fafd7351c5abb9925a075132941"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,0529f2d163df9e2cd2ae8254dfb63806"
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.sampled_test_1.fastq.gz:md5,e5f44fafd7351c5abb9925a075132941"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,0529f2d163df9e2cd2ae8254dfb63806"
+                ]
+            }
+        ],
+        "timestamp": "2024-02-22T15:58:37.679954"
+    },
+    "sarscov2_sample_singleend_fqgz": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.sampled_test_1.fastq.gz:md5,e5f44fafd7351c5abb9925a075132941"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,0529f2d163df9e2cd2ae8254dfb63806"
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.sampled_test_1.fastq.gz:md5,e5f44fafd7351c5abb9925a075132941"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,0529f2d163df9e2cd2ae8254dfb63806"
+                ]
+            }
+        ],
+        "timestamp": "2024-02-22T15:58:29.474491"
+    }
+}

--- a/modules/nf-core/seqtk/sample/tests/standard.config
+++ b/modules/nf-core/seqtk/sample/tests/standard.config
@@ -1,0 +1,6 @@
+process {
+    withName: SEQTK_SAMPLE {
+        ext.args = '-s100'
+        ext.prefix = { "${meta.id}.sampled" }
+    }
+}

--- a/modules/nf-core/seqtk/sample/tests/tags.yml
+++ b/modules/nf-core/seqtk/sample/tests/tags.yml
@@ -1,0 +1,2 @@
+seqtk/sample:
+  - "modules/nf-core/seqtk/sample/**"

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,7 @@ params {
     // TODO nf-core: Specify your pipeline's command line flags
     // Input options
     input                      = null
-
+    sample_size                = null
     // References
     genome                     = null
     fasta                      = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,7 @@ params {
     // TODO nf-core: Specify your pipeline's command line flags
     // Input options
     input                      = null
-    sample_size                = null
+    sample_size                = 0
     // References
     genome                     = null
     fasta                      = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -23,8 +23,15 @@
                     "help_text": "You will need to create a design file with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 3 columns, and a header row. See [usage docs](https://nf-co.re/seqinspector/usage#samplesheet-input).",
                     "fa_icon": "fas fa-file-csv"
                 },
+                "sample_size": {
+                    "type": "integer",
+                    "default": null,
+                    "description": "Subset this number of reads.",
+                    "help_text": "Samples will be subsetted to this number of reads. If null, no subsampling will be performed."
+                },
                 "outdir": {
                     "type": "string",
+                    "default": null,
                     "format": "directory-path",
                     "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
                     "fa_icon": "fas fa-folder-open"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -25,9 +25,9 @@
                 },
                 "sample_size": {
                     "type": "integer",
-                    "default": null,
+                    "default": 0,
                     "description": "Subset this number of reads.",
-                    "help_text": "Samples will be subsetted to this number of reads. If null, no subsampling will be performed."
+                    "help_text": "Samples will be subsetted to this number of reads. If 0 (default), no subsampling will be performed."
                 },
                 "outdir": {
                     "type": "string",

--- a/tests/MiSeq.main.nf.test.snap
+++ b/tests/MiSeq.main.nf.test.snap
@@ -4,12 +4,12 @@
             "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
             "multiqc_fastqc.txt:md5,7b1b7fd457b60404768045b148d4c0a8",
             "multiqc_general_stats.txt:md5,5b28a83b14cb2fe88d084d08900ebdbf",
-            "multiqc_software_versions.txt:md5,a3698a2d32e8695c38d50e3d17de5fe3"
+            "multiqc_software_versions.txt:md5,49e3596d49ee49d967d3b6c363b486d5"
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.10.0"
+            "nf-test": "0.9.1",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T13:18:10.3675973"
+        "timestamp": "2024-10-28T15:06:30.86052858"
     }
 }

--- a/tests/NovaSeq6000.main.nf.test.snap
+++ b/tests/NovaSeq6000.main.nf.test.snap
@@ -4,28 +4,28 @@
             "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
             "multiqc_fastqc.txt:md5,3730f9046b20ac5c17a86db0a33f8d5d",
             "multiqc_general_stats.txt:md5,25abe0f6a35eb4a3b056fc3cf5c13732",
-            "multiqc_software_versions.txt:md5,a3698a2d32e8695c38d50e3d17de5fe3",
+            "multiqc_software_versions.txt:md5,49e3596d49ee49d967d3b6c363b486d5",
             "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
             "multiqc_fastqc.txt:md5,8284e25ccc21041cf3b5a32eb6a51e78",
             "multiqc_general_stats.txt:md5,90ee35137492b80aab36ef67f72d8921",
-            "multiqc_software_versions.txt:md5,a3698a2d32e8695c38d50e3d17de5fe3",
+            "multiqc_software_versions.txt:md5,49e3596d49ee49d967d3b6c363b486d5",
             "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
             "multiqc_fastqc.txt:md5,f38ffdc112c73af3a41ed15848a3761f",
             "multiqc_general_stats.txt:md5,d62a2fc39e674d98783d408791803148",
-            "multiqc_software_versions.txt:md5,a3698a2d32e8695c38d50e3d17de5fe3",
+            "multiqc_software_versions.txt:md5,49e3596d49ee49d967d3b6c363b486d5",
             "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
             "multiqc_fastqc.txt:md5,7ff71ceb8ecdf086331047f8860c3347",
             "multiqc_general_stats.txt:md5,2f09b8f199ac40cf67ba50843cebd29c",
-            "multiqc_software_versions.txt:md5,a3698a2d32e8695c38d50e3d17de5fe3",
+            "multiqc_software_versions.txt:md5,49e3596d49ee49d967d3b6c363b486d5",
             "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
             "multiqc_fastqc.txt:md5,519ff344a896ac369bba4d5c5b8be7b5",
             "multiqc_general_stats.txt:md5,6a1c16f068d7ba3a9225a17eb570ed9a",
-            "multiqc_software_versions.txt:md5,a3698a2d32e8695c38d50e3d17de5fe3"
+            "multiqc_software_versions.txt:md5,49e3596d49ee49d967d3b6c363b486d5"
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.10.0"
+            "nf-test": "0.9.1",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T13:19:13.226135825"
+        "timestamp": "2024-10-28T15:07:59.897711748"
     }
 }

--- a/tests/NovaSeq6000.main_subsample.nf.test
+++ b/tests/NovaSeq6000.main_subsample.nf.test
@@ -1,11 +1,11 @@
 nextflow_pipeline {
 
-    name "Test Workflow main.nf on NovaSeq6000 data"
+    name "Test Workflow main.nf on NovaSeq6000 data sample size 90"
     script "../main.nf"
     tag "seqinspector"
     tag "PIPELINE"
 
-    test("NovaSeq6000 data test") {
+    test("NovaSeq6000 data test sample size") {
 
         when {
             config "./NovaSeq6000.main_subsample.nf.test.config"

--- a/tests/NovaSeq6000.main_subsample.nf.test
+++ b/tests/NovaSeq6000.main_subsample.nf.test
@@ -1,0 +1,50 @@
+nextflow_pipeline {
+
+    name "Test Workflow main.nf on NovaSeq6000 data"
+    script "../main.nf"
+    tag "seqinspector"
+    tag "PIPELINE"
+
+    test("NovaSeq6000 data test") {
+
+        when {
+            config "./NovaSeq6000.main_subsample.nf.test.config"
+            params {
+                outdir = "$outputDir"
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    path("$outputDir/multiqc/global_report/multiqc_data/multiqc_citations.txt"),
+                    path("$outputDir/multiqc/global_report/multiqc_data/multiqc_fastqc.txt"),
+                    path("$outputDir/multiqc/global_report/multiqc_data/multiqc_general_stats.txt"),
+                    path("$outputDir/multiqc/global_report/multiqc_data/multiqc_software_versions.txt"),
+
+                    path("$outputDir/multiqc/group_reports/lane1/multiqc_data/multiqc_citations.txt"),
+                    path("$outputDir/multiqc/group_reports/lane1/multiqc_data/multiqc_fastqc.txt"),
+                    path("$outputDir/multiqc/group_reports/lane1/multiqc_data/multiqc_general_stats.txt"),
+                    path("$outputDir/multiqc/group_reports/lane1/multiqc_data/multiqc_software_versions.txt"),
+
+                    path("$outputDir/multiqc/group_reports/group1/multiqc_data/multiqc_citations.txt"),
+                    path("$outputDir/multiqc/group_reports/group1/multiqc_data/multiqc_fastqc.txt"),
+                    path("$outputDir/multiqc/group_reports/group1/multiqc_data/multiqc_general_stats.txt"),
+                    path("$outputDir/multiqc/group_reports/group1/multiqc_data/multiqc_software_versions.txt"),
+
+                    path("$outputDir/multiqc/group_reports/group2/multiqc_data/multiqc_citations.txt"),
+                    path("$outputDir/multiqc/group_reports/group2/multiqc_data/multiqc_fastqc.txt"),
+                    path("$outputDir/multiqc/group_reports/group2/multiqc_data/multiqc_general_stats.txt"),
+                    path("$outputDir/multiqc/group_reports/group2/multiqc_data/multiqc_software_versions.txt"),
+
+                    path("$outputDir/multiqc/group_reports/test/multiqc_data/multiqc_citations.txt"),
+                    path("$outputDir/multiqc/group_reports/test/multiqc_data/multiqc_fastqc.txt"),
+                    path("$outputDir/multiqc/group_reports/test/multiqc_data/multiqc_general_stats.txt"),
+                    path("$outputDir/multiqc/group_reports/test/multiqc_data/multiqc_software_versions.txt"),
+                    ).match()
+                },
+            )
+        }
+    }
+}

--- a/tests/NovaSeq6000.main_subsample.nf.test.config
+++ b/tests/NovaSeq6000.main_subsample.nf.test.config
@@ -1,0 +1,8 @@
+// Load the basic test config
+includeConfig 'nextflow.config'
+
+// Load the correct samplesheet for that test
+params {
+    input  = params.pipelines_testdata_base_path + 'seqinspector/testdata/NovaSeq6000/samplesheet.csv'
+    sample_size = 90
+}

--- a/tests/NovaSeq6000.main_subsample.nf.test.snap
+++ b/tests/NovaSeq6000.main_subsample.nf.test.snap
@@ -1,31 +1,31 @@
 {
-    "NovaSeq6000 data test": {
+    "NovaSeq6000 data test sample size": {
         "content": [
             "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
             "multiqc_fastqc.txt:md5,aba942d1e6996b579f19798e5673f514",
-            "multiqc_general_stats.txt:md5,c4f40f2313aadc38619e7487226e8d93",
+            "multiqc_general_stats.txt:md5,ad1ec9c64cbdb1131a26aeb6de51e31c",
             "multiqc_software_versions.txt:md5,b7d1ca14785a9361f0a39ce1b6a02686",
             "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
             "multiqc_fastqc.txt:md5,aa1b8d6adae86005ea7a8b2e901099b8",
-            "multiqc_general_stats.txt:md5,d5d73d2888cd9895e5f116e5b869e73c",
+            "multiqc_general_stats.txt:md5,c73c8d10568a56f6534d280fff701e60",
             "multiqc_software_versions.txt:md5,b7d1ca14785a9361f0a39ce1b6a02686",
             "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
             "multiqc_fastqc.txt:md5,ff996e1d3dc4a46e0c9535e54d51ccab",
-            "multiqc_general_stats.txt:md5,d01ec30a262b69bc5749b0ed108a950a",
+            "multiqc_general_stats.txt:md5,834e1868b887171cfda72029bbbe2d3f",
             "multiqc_software_versions.txt:md5,b7d1ca14785a9361f0a39ce1b6a02686",
             "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
             "multiqc_fastqc.txt:md5,3df36ecfe76b25b0c22dcda84bce2b3b",
-            "multiqc_general_stats.txt:md5,4dffc0d1169c49adde819d4467ffb775",
+            "multiqc_general_stats.txt:md5,274a001b007521970f14d68bd176e5be",
             "multiqc_software_versions.txt:md5,b7d1ca14785a9361f0a39ce1b6a02686",
             "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
             "multiqc_fastqc.txt:md5,ce61b4ce4b1d76ec3f20de3bf0c9ec7f",
-            "multiqc_general_stats.txt:md5,05f8dfeea9fca7f4c16ba9d553af4c69",
+            "multiqc_general_stats.txt:md5,d476ad59458a035a329605d5284b6012",
             "multiqc_software_versions.txt:md5,b7d1ca14785a9361f0a39ce1b6a02686"
         ],
         "meta": {
             "nf-test": "0.9.1",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T14:05:44.868455454"
+        "timestamp": "2024-10-28T15:09:41.503580136"
     }
 }

--- a/tests/NovaSeq6000.main_subsample.nf.test.snap
+++ b/tests/NovaSeq6000.main_subsample.nf.test.snap
@@ -1,0 +1,31 @@
+{
+    "NovaSeq6000 data test": {
+        "content": [
+            "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
+            "multiqc_fastqc.txt:md5,aba942d1e6996b579f19798e5673f514",
+            "multiqc_general_stats.txt:md5,c4f40f2313aadc38619e7487226e8d93",
+            "multiqc_software_versions.txt:md5,b7d1ca14785a9361f0a39ce1b6a02686",
+            "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
+            "multiqc_fastqc.txt:md5,aa1b8d6adae86005ea7a8b2e901099b8",
+            "multiqc_general_stats.txt:md5,d5d73d2888cd9895e5f116e5b869e73c",
+            "multiqc_software_versions.txt:md5,b7d1ca14785a9361f0a39ce1b6a02686",
+            "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
+            "multiqc_fastqc.txt:md5,ff996e1d3dc4a46e0c9535e54d51ccab",
+            "multiqc_general_stats.txt:md5,d01ec30a262b69bc5749b0ed108a950a",
+            "multiqc_software_versions.txt:md5,b7d1ca14785a9361f0a39ce1b6a02686",
+            "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
+            "multiqc_fastqc.txt:md5,3df36ecfe76b25b0c22dcda84bce2b3b",
+            "multiqc_general_stats.txt:md5,4dffc0d1169c49adde819d4467ffb775",
+            "multiqc_software_versions.txt:md5,b7d1ca14785a9361f0a39ce1b6a02686",
+            "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
+            "multiqc_fastqc.txt:md5,ce61b4ce4b1d76ec3f20de3bf0c9ec7f",
+            "multiqc_general_stats.txt:md5,05f8dfeea9fca7f4c16ba9d553af4c69",
+            "multiqc_software_versions.txt:md5,b7d1ca14785a9361f0a39ce1b6a02686"
+        ],
+        "meta": {
+            "nf-test": "0.9.1",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-28T14:05:44.868455454"
+    }
+}

--- a/tests/PromethION.main.nf.test.snap
+++ b/tests/PromethION.main.nf.test.snap
@@ -4,12 +4,12 @@
             "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
             "multiqc_fastqc.txt:md5,1a4b472e13cadc770832b0e20d1de7b0",
             "multiqc_general_stats.txt:md5,409cefc7f17f95d176ced6032bf8fb32",
-            "multiqc_software_versions.txt:md5,a3698a2d32e8695c38d50e3d17de5fe3"
+            "multiqc_software_versions.txt:md5,49e3596d49ee49d967d3b6c363b486d5"
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.10.0"
+            "nf-test": "0.9.1",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-28T13:19:57.261730412"
+        "timestamp": "2024-10-28T15:10:20.186073387"
     }
 }

--- a/workflows/seqinspector.nf
+++ b/workflows/seqinspector.nf
@@ -35,7 +35,7 @@ workflow SEQINSPECTOR {
     //
     // MODULE: Run Seqkit sample to perform subsampling
     //
-    if (params.sample_size) {
+    if (params.sample_size > 0 ) {
         ch_sample_sized = SEQTK_SAMPLE(ch_samplesheet.map {
             meta, reads -> [meta, reads, params.sample_size]
         }).reads


### PR DESCRIPTION
Closes #28.
Regarding this:
> Additionally, [the module](https://nf-co.re/modules/seqtk_sample/) should be modified to allow for an optional value channel to specify the seed to make the subsampling deterministic and reproducible. This is required for testing and also useful in certain real-world scenarios.
SeqKit sample already uses a default according to the documentation: 
https://bioinf.shenwei.me/seqkit/usage/#sample see `-s`

Snapshots updated after merging https://github.com/nf-core/seqinspector/pull/49
## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/seqinspector/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/seqinspector _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [X] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [X] Usage Documentation in `docs/usage.md` is updated.
- [X] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
