### PR TITLE
Making fastq_screen_references value to use parentDir

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -1,6 +1,9 @@
 lint:
   files_unchanged:
     - .github/CONTRIBUTING.md
+  nextflow_config:
+    - config_defaults:
+        - params.fastq_screen_references
 nf_core_version: 3.2.0
 repository_type: pipeline
 template:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Initial release of nf-core/seqinspector, created with the [nf-core](https://nf-c
 - [#71](https://github.com/nf-core/seqinspector/pull/71) FASTQSCREEN does not fail when multiple reads are provided.
 - [#99](https://github.com/nf-core/seqinspector/pull/99) Fix group reports for paired reads
 - [#107](https://github.com/nf-core/seqinspector/pull/107) Put SeqFU-stats section reports together
+- [#112](https://github.com/nf-core/seqinspector/pull/112) Making fastq_screen_references value to use parentDir
 
 ### `Dependencies`
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,7 +21,7 @@ params {
     igenomes_ignore            = false
 
     // Fastqscreen options
-    fastq_screen_references    = './assets/example_fastq_screen_references.csv'
+    fastq_screen_references    = "${projectDir}/assets/example_fastq_screen_references.csv"
 
     // MultiQC options
     multiqc_config             = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -94,7 +94,7 @@
                 },
                 "fastq_screen_references": {
                     "type": "string",
-                    "default": "./assets/example_fastq_screen_references.csv",
+                    "default": "${projectDir}/assets/example_fastq_screen_references.csv",
                     "fa_icon": "fas fa-search",
                     "description": "A .csv of reference genomes to be mapped against by FastQ Screen"
                 }


### PR DESCRIPTION
fastq_screen_references value was been interpreted differently depending on where the pipeline runs from. This code fixes it by setting it to always point to baseDir

<!--
# nf-core/seqinspector pull request

Many thanks for contributing to nf-core/seqinspector!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/seqinspector/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
