### PR TITLE
Allow relative sample size input in subsampling

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -92,7 +92,7 @@ genome: 'GRCh37'
 
 You can also generate such `YAML`/`JSON` files via [nf-core/launch](https://nf-co.re/launch).
 
-Optionally, the `sample_size` parameter allows you to subset a random number of reads to be analysed. Note that it refers to an absolute number.
+Optionally, the `sample_size` parameter allows you to subset a random number of reads to be analysed. Both absolute numbers (e.g 10000) and relative numbers (e.g 0.25) can be specified.
 
 ```bash
 nextflow run nf-core/seqinspector --input ./samplesheet.csv --outdir ./results --sample_size 1000000 -profile docker

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -24,9 +24,9 @@
                     "fa_icon": "fas fa-file-csv"
                 },
                 "sample_size": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "Take this number of reads as a subset.",
-                    "help_text": "Choose the size of the subset or 0, if no subsampling shall be performed. Note that it refers to an absolute number.",
+                    "help_text": "Choose the size of the subset or 0, if no subsampling shall be performed. Both absolute numbers (e.g 10000) and relative numbers (e.g 0.25) can be specified.",
                     "default": 0
                 },
                 "outdir": {


### PR DESCRIPTION
This code allows subsampling to work with relative numbers too as the initial implementation limited it to absolute number of reads (https://github.com/nf-core/seqinspector/pull/50).
[seqtk_sample module](https://nf-co.re/modules/seqtk_sample/#:~:text=Fraction%20(%3C1.0)%20or%20number%20(%3E%3D1)%20of%20reads%20to%20sample.) itself allows passing fractions as the sample_size thus only our schema has been updated here to allow both integers and floats

Fixes #60 
 
Co-authored-by: agrima2010
Co-authored-by: kjelinjonas

<!--
# nf-core/seqinspector pull request

Many thanks for contributing to nf-core/seqinspector!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/seqinspector/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/seqinspector/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/seqinspector _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ X] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [X] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
