### PR TITLE
Fix tool bundles documentation to match code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#216](https://github.com/nf-core/seqinspector/pull/216) Fixed meta.id that resulted in all SEQFU_STATS processes with the same tag name
 - [#224](https://github.com/nf-core/seqinspector/pull/224) Fix workflow output syntax for future Nextflow releases
 - [#226](https://github.com/nf-core/seqinspector/pull/226) Fix parameter `tools_bundle` not accepting `null` for custom tool selection
+- [#239](https://github.com/nf-core/seqinspector/pull/239) Fix tool bundles documentation to match code
 
 ### `Changed`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -154,7 +154,7 @@ Be aware that the default tools will still be run. In order to ONLY run the sele
 --tools fastqscreen,rundirparser --tools_bundle null
 ```
 
-Currently the `tools` param can have the following values: fastqc, fastqscreen, picard_collecthsmetrics, picard_collectmultiplemetrics, rundirparser and seqfu_stats.
+Currently the `tools` param can have the following values: bbmap_clumpify, checkqc, fastp, fastqc, fastqe, fastqscreen, fq_lint, kraken2, multiqcsav, picard_collecthsmetrics, picard_collectmultiplemetrics, rundirparser, seqkit_stats, seqfu_stats, sequali and toulligqc.
 
 #### Skip specific tools
 
@@ -181,9 +181,11 @@ Tools:
 
 - fastqc
 - fastqscreen
+- fq_lint
 - picard_collectmultiplemetrics
 - rundirparser
 - seqfu_stats
+- sequali
 
 </details>
 
@@ -197,13 +199,19 @@ Requirements:
 
 Tools:
 
-- checkQC
+- bbmap_clumpify
+- checkqc
 - fastqc
+- fastqe
 - fastqscreen
+- fq_lint
+- multiqcsav
 - picard_collecthsmetrics
 - picard_collectmultiplemetrics
 - rundirparser
+- seqkit_stats
 - seqfu_stats
+- sequali
 - toulligqc
 
 </details>
@@ -244,6 +252,8 @@ Tools:
 
 - fastqc
 - fastqscreen
+- fq_lint
+- seqkit_stats
 
 </details>
 
@@ -256,7 +266,8 @@ Requirements:
 
 Tools:
 
-- checkQC
+- checkqc
+- multiqcsav
 - rundirparser
 - seqfu_stats
 </details>
@@ -268,7 +279,8 @@ Tools:
 
 - fastqc
 - fastqscreen
-- seqfu_stats
+- seqkit_stats
+- sequali
 - toulligqc
 
 </details>


### PR DESCRIPTION
Updates usage.md tool bundles documentation to match the actual code in `utils_nfcore_seqinspector_pipeline/main.nf`:

- **default**: Added `fq_lint`, `sequali`
- **all**: Added `bbmap_clumpify`, `fastqe`, `fq_lint`, `multiqcsav`, `seqkit_stats`, `sequali`
- **fastq**: Added `fq_lint`, `seqkit_stats`
- **illumina**: Added `multiqcsav`
- **ont**: Added `seqkit_stats`, `sequali`

Also updated the complete tools list to include all 16 selectable tools.