### PR TITLE
Skip conda tests for CheckQC

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -78,6 +78,8 @@ jobs:
             profile: "conda"
           - isMain: false
             profile: "singularity"
+          - isMain: true
+            NXF_VER: "latest-everything"
         NXF_VER:
           - "25.10.4"
           - "latest-everything"

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -51,6 +51,7 @@ jobs:
           NFT_VER: ${{ env.NFT_VER }}
         with:
           max_shards: 7
+          tags: "cpu,cpu_conda"
 
       - name: debug
         run: |
@@ -100,6 +101,7 @@ jobs:
           profile: ${{ matrix.profile }}
           shard: ${{ matrix.shard }}
           total_shards: ${{ env.TOTAL_SHARDS }}
+          tags: ${{ matrix.profile == 'conda' && 'cpu_conda' || 'cpu,cpu_conda' }}
 
       - name: Report test status
         if: ${{ always() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## dev
+
+### `Changed`
+
+- [#252](https://github.com/nf-core/seqinspector/pull/252) Skip conda tests for CheckQC
+
 ## [1.1.0](https://github.com/nf-core/seqinspector/releases/tag/1.1.0) - Veronica Mars
 
 ### `Added`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,6 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## dev
-
-### `Changed`
-
-- [#252](https://github.com/nf-core/seqinspector/pull/252) Skip conda tests for CheckQC
-
 ## [1.1.0](https://github.com/nf-core/seqinspector/releases/tag/1.1.0) - Veronica Mars
 
 ### `Added`
@@ -64,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#249](https://github.com/nf-core/seqinspector/pull/249) Create meta.yml files for local subworkflows
 - [#249](https://github.com/nf-core/seqinspector/pull/249) Update modules
 - [#250](https://github.com/nf-core/seqinspector/pull/250) Prepare release 1.1.0
+- [#252](https://github.com/nf-core/seqinspector/pull/252) Skip conda tests for CheckQC
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#249](https://github.com/nf-core/seqinspector/pull/249) Create meta.yml files for local subworkflows
 - [#249](https://github.com/nf-core/seqinspector/pull/249) Update modules
 - [#250](https://github.com/nf-core/seqinspector/pull/250) Prepare release 1.1.0
-- [#252](https://github.com/nf-core/seqinspector/pull/252) Skip conda tests for CheckQC and latest-everything Nextflow version on main/master
+- [#252](https://github.com/nf-core/seqinspector/pull/252) Skip conda tests for CheckQC
+- [#252](https://github.com/nf-core/seqinspector/pull/252) Skip latest-everything Nextflow version on main/master
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#249](https://github.com/nf-core/seqinspector/pull/249) Create meta.yml files for local subworkflows
 - [#249](https://github.com/nf-core/seqinspector/pull/249) Update modules
 - [#250](https://github.com/nf-core/seqinspector/pull/250) Prepare release 1.1.0
-- [#252](https://github.com/nf-core/seqinspector/pull/252) Skip conda tests for CheckQC
-- Skip latest-everything Nextflow version on main/master
+- [#252](https://github.com/nf-core/seqinspector/pull/252) Skip conda tests for CheckQC and latest-everything Nextflow version on main/master
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#249](https://github.com/nf-core/seqinspector/pull/249) Update modules
 - [#250](https://github.com/nf-core/seqinspector/pull/250) Prepare release 1.1.0
 - [#252](https://github.com/nf-core/seqinspector/pull/252) Skip conda tests for CheckQC
+- Skip latest-everything Nextflow version on main/master
 
 ### `Dependencies`
 

--- a/tests/missing_rundir.nf.test
+++ b/tests/missing_rundir.nf.test
@@ -23,7 +23,6 @@ nextflow_pipeline {
                 tools: 'checkqc,fastqc,multiqcsav,rundirparser',
                 tools_bundle: null,
             ],
-            no_conda: true,
         ],
         [
             name: "NovaSeq6000 data test - checkqc,fastqc,multiqcsav,rundirparser - missing rundir - stub",
@@ -44,7 +43,6 @@ nextflow_pipeline {
                 tools_bundle: null,
             ],
             stub: true,
-            no_conda: true,
         ],
     ]
 

--- a/tests/missing_rundir.nf.test
+++ b/tests/missing_rundir.nf.test
@@ -14,6 +14,7 @@ nextflow_pipeline {
             ],
             rundir_folder: pipelines_testdata_base_path + 'seqinspector/data/rundir/200624_A00834_0183_BHMTFYDRXX.tar.gz',
             rundir_samplesheet: pipelines_testdata_base_path + 'seqinspector/samplesheet/1.0/novaseq6000_missing_rundir.csv',
+            no_conda: true,
         ],
         [
             name: "NovaSeq6000 data test - checkqc,fastqc,multiqcsav,rundirparser - no rundir",
@@ -22,6 +23,7 @@ nextflow_pipeline {
                 tools: 'checkqc,fastqc,multiqcsav,rundirparser',
                 tools_bundle: null,
             ],
+            no_conda: true,
         ],
         [
             name: "NovaSeq6000 data test - checkqc,fastqc,multiqcsav,rundirparser - missing rundir - stub",
@@ -32,6 +34,7 @@ nextflow_pipeline {
             rundir_folder: pipelines_testdata_base_path + 'seqinspector/data/rundir/200624_A00834_0183_BHMTFYDRXX.tar.gz',
             rundir_samplesheet: pipelines_testdata_base_path + 'seqinspector/samplesheet/1.0/novaseq6000_missing_rundir.csv',
             stub: true,
+            no_conda: true,
         ],
         [
             name: "NovaSeq6000 data test - checkqc,fastqc,multiqcsav,rundirparser - no rundir - stub",
@@ -41,6 +44,7 @@ nextflow_pipeline {
                 tools_bundle: null,
             ],
             stub: true,
+            no_conda: true,
         ],
     ]
 

--- a/tests/missing_rundir.nf.test
+++ b/tests/missing_rundir.nf.test
@@ -32,8 +32,8 @@ nextflow_pipeline {
             ],
             rundir_folder: pipelines_testdata_base_path + 'seqinspector/data/rundir/200624_A00834_0183_BHMTFYDRXX.tar.gz',
             rundir_samplesheet: pipelines_testdata_base_path + 'seqinspector/samplesheet/1.0/novaseq6000_missing_rundir.csv',
-            stub: true,
             no_conda: true,
+            stub: true,
         ],
         [
             name: "NovaSeq6000 data test - checkqc,fastqc,multiqcsav,rundirparser - no rundir - stub",

--- a/tests/tools_checkqc.nf.test
+++ b/tests/tools_checkqc.nf.test
@@ -13,6 +13,7 @@ nextflow_pipeline {
                 tools: 'checkqc',
                 tools_bundle: null,
             ],
+            no_conda: true,
         ],
         [
             name: "NovaSeq6000 data test - checkqc with config",
@@ -21,6 +22,7 @@ nextflow_pipeline {
                 tools: 'checkqc',
                 tools_bundle: null,
             ],
+            no_conda: true,
         ],
         [
             name: "NovaSeq6000 data test - checkqc - stub",
@@ -29,6 +31,7 @@ nextflow_pipeline {
                 tools_bundle: null,
             ],
             stub: true,
+            no_conda: true,
         ],
         [
             name: "NovaSeq6000 data test - checkqc with config - stub",
@@ -38,6 +41,7 @@ nextflow_pipeline {
                 tools_bundle: null,
             ],
             stub: true,
+            no_conda: true,
         ],
     ]
 


### PR DESCRIPTION
## Changes

- Add `no_conda: true` to CheckQC test scenarios in `tools_checkqc.nf.test` and `missing_rundir.nf.test`
- Update CI workflow to pass `tags` to nf-test actions for conda profile filtering

CheckQC is a module that cannot work with conda, so we skip conda tests for all pipeline tests running CheckQC. This follows the same pattern used in nf-core/sarek.

## Checklist

- [x] Code follows nf-core conventions
- [x] Tests pass
- [x] Documentation updated (if needed)
- [x] CHANGELOG updated (if needed)

## Generated by

Generated by opencode (mimo-v2.5)