### PR TITLE
Fix rundirparser test snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### `Fixed`
+
+- Fix rundirparser test snapshots to use full topic object instead of individual channels
+
 ## [1.1.0](https://github.com/nf-core/seqinspector/releases/tag/1.1.0) - Veronica Mars
 
 ### `Added`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,6 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### `Fixed`
-
-- Fix rundirparser test snapshots to use full topic object instead of individual channels
-
 ## [1.1.0](https://github.com/nf-core/seqinspector/releases/tag/1.1.0) - Veronica Mars
 
 ### `Added`
@@ -44,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#243](https://github.com/nf-core/seqinspector/pull/243) Fix typos, broken link, missing `</details>` tag, and stray content in output documentation
 - [#245](https://github.com/nf-core/seqinspector/pull/245) Fix repeated listing of CollectHsMetrics
 - [#253](https://github.com/nf-core/seqinspector/pull/253) Fix CHANGELOG, missing Update in README and CITATIONS
+- Fix rundirparser test snapshots to use full topic object instead of individual channels
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#243](https://github.com/nf-core/seqinspector/pull/243) Fix typos, broken link, missing `</details>` tag, and stray content in output documentation
 - [#245](https://github.com/nf-core/seqinspector/pull/245) Fix repeated listing of CollectHsMetrics
 - [#253](https://github.com/nf-core/seqinspector/pull/253) Fix CHANGELOG, missing Update in README and CITATIONS
-- Fix rundirparser test snapshots to use full topic object instead of individual channels
+- [#255](https://github.com/nf-core/seqinspector/pull/255) Fix rundirparser test snapshots to use full topic object instead of individual channels
 
 ### `Changed`
 

--- a/modules/local/rundirparser/tests/main.nf.test
+++ b/modules/local/rundirparser/tests/main.nf.test
@@ -19,10 +19,7 @@ nextflow_process {
         }
         then {
             assert process.success
-            assert snapshot(
-                topics.multiqc_files,
-                topics.versions
-            ).match()
+            assert snapshot(topics).match()
         }
     }
 
@@ -41,10 +38,7 @@ nextflow_process {
         }
         then {
             assert process.success
-            assert snapshot(
-                topics.multiqc_files,
-                topics.versions
-            ).match()
+            assert snapshot(topics).match()
         }
     }
 }

--- a/modules/local/rundirparser/tests/main.nf.test.snap
+++ b/modules/local/rundirparser/tests/main.nf.test.snap
@@ -1,74 +1,78 @@
 {
     "NovaSeq6000": {
         "content": [
-            [
-                [
-                    {
-                        "id": "200624_A00834_0183_BHMTFYDRXX"
-                    },
-                    "RUNDIRPARSER",
-                    "rundirparser",
-                    "illumina_mqc.yml:md5,29e05fed18bca0e9a857c992b6d59a40"
-                ]
-            ],
-            [
-                [
-                    "RUNDIRPARSER",
-                    "python",
-                    "3.13.2"
+            {
+                "multiqc_files": [
+                    [
+                        {
+                            "id": "200624_A00834_0183_BHMTFYDRXX"
+                        },
+                        "RUNDIRPARSER",
+                        "rundirparser",
+                        "illumina_mqc.yml:md5,29e05fed18bca0e9a857c992b6d59a40"
+                    ]
                 ],
-                [
-                    "RUNDIRPARSER",
-                    "pyyaml",
-                    "6.0.2"
-                ],
-                [
-                    "RUNDIRPARSER",
-                    "rundirparser",
-                    "1.0.1"
+                "versions": [
+                    [
+                        "RUNDIRPARSER",
+                        "python",
+                        "3.13.2"
+                    ],
+                    [
+                        "RUNDIRPARSER",
+                        "pyyaml",
+                        "6.0.2"
+                    ],
+                    [
+                        "RUNDIRPARSER",
+                        "rundirparser",
+                        "1.0.1"
+                    ]
                 ]
-            ]
+            }
         ],
-        "timestamp": "2026-06-16T16:34:39.967986788",
+        "timestamp": "2026-07-14T13:59:22.481197877",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.3"
+            "nextflow": "26.04.4"
         }
     },
     "NovaSeq6000 - stub": {
         "content": [
-            [
-                [
-                    {
-                        "id": "200624_A00834_0183_BHMTFYDRXX"
-                    },
-                    "RUNDIRPARSER",
-                    "rundirparser",
-                    "illumina_mqc.yml:md5,d41d8cd98f00b204e9800998ecf8427e"
-                ]
-            ],
-            [
-                [
-                    "RUNDIRPARSER",
-                    "python",
-                    "3.13.2"
+            {
+                "multiqc_files": [
+                    [
+                        {
+                            "id": "200624_A00834_0183_BHMTFYDRXX"
+                        },
+                        "RUNDIRPARSER",
+                        "rundirparser",
+                        "illumina_mqc.yml:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
-                [
-                    "RUNDIRPARSER",
-                    "pyyaml",
-                    "6.0.2"
-                ],
-                [
-                    "RUNDIRPARSER",
-                    "rundirparser",
-                    "1.0.1"
+                "versions": [
+                    [
+                        "RUNDIRPARSER",
+                        "python",
+                        "3.13.2"
+                    ],
+                    [
+                        "RUNDIRPARSER",
+                        "pyyaml",
+                        "6.0.2"
+                    ],
+                    [
+                        "RUNDIRPARSER",
+                        "rundirparser",
+                        "1.0.1"
+                    ]
                 ]
-            ]
+            }
         ],
-        "timestamp": "2026-06-16T16:34:50.171365737",
+        "timestamp": "2026-07-14T13:59:33.97253431",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.3"
+            "nextflow": "26.04.4"
         }
     }
 }


### PR DESCRIPTION
Simplify rundirparser test snapshots to use the full `topics` object instead of individual `topics.multiqc_files` and `topics.versions` channels.