### PR TITLE
Address review comments from PR #251

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#245](https://github.com/nf-core/seqinspector/pull/245) Fix repeated listing of CollectHsMetrics
 - [#253](https://github.com/nf-core/seqinspector/pull/253) Fix CHANGELOG, missing Update in README and CITATIONS
 - [#255](https://github.com/nf-core/seqinspector/pull/255) Fix rundirparser test snapshots to use full topic object instead of individual channels
-- Address review comments from PR #251: improve docs, add tool descriptions to output.md, remove duplicated param tables from usage.md
+- [#256](https://github.com/nf-core/seqinspector/pull/256) Address review comments from PR #251: improve docs, add tool descriptions to output.md, remove duplicated param tables from usage.md
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#245](https://github.com/nf-core/seqinspector/pull/245) Fix repeated listing of CollectHsMetrics
 - [#253](https://github.com/nf-core/seqinspector/pull/253) Fix CHANGELOG, missing Update in README and CITATIONS
 - [#255](https://github.com/nf-core/seqinspector/pull/255) Fix rundirparser test snapshots to use full topic object instead of individual channels
+- Address review comments from PR #251: improve docs, add tool descriptions to output.md, remove duplicated param tables from usage.md
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#243](https://github.com/nf-core/seqinspector/pull/243) Add `--subsample_tools` parameter to control which tools run on subsampled data
 - [#246](https://github.com/nf-core/seqinspector/pull/246) Added riker module for BAM-level QC metrics collection
 - [#247](https://github.com/nf-core/seqinspector/pull/247) Add `AGENTS.md` file with nf-core agent instructions
+- [#256](https://github.com/nf-core/seqinspector/pull/256) Improve docs
 
 ### `Fixed`
 
@@ -39,7 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#245](https://github.com/nf-core/seqinspector/pull/245) Fix repeated listing of CollectHsMetrics
 - [#253](https://github.com/nf-core/seqinspector/pull/253) Fix CHANGELOG, missing Update in README and CITATIONS
 - [#255](https://github.com/nf-core/seqinspector/pull/255) Fix rundirparser test snapshots to use full topic object instead of individual channels
-- [#256](https://github.com/nf-core/seqinspector/pull/256) Address review comments from PR #251: improve docs, add tool descriptions to output.md, remove duplicated param tables from usage.md
 
 ### `Changed`
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -202,8 +202,11 @@ If you wish to add a new tool to the seqinspector pipeline, please use the follo
 10. Update MultiQC config `assets/multiqc_config.yml` so relevant suffixes, file name clean up and module plots are in the appropriate order. If applicable, add a [MultiQC](https://https://multiqc.info/) module.
 11. Add your tool to the tools selection:
     - In the local subworkflow `utils_nfcore_seqinspector_pipeline` find the lists of tool lists in `main.nf` and add your tool to the list `all` and any other appropriate list.
-    - In the `nextflow_schema.json` add your tool to the pattern of the `tools` properties.
-    - update the list of tools in the `Tools Selection` section in the `usage.md` file.
+    - In `nextflow_schema.json`:
+      - Add your tool to the `pattern` regex of the `tools` property.
+      - Add your tool to the `pattern` regex of the `skip_tools` property.
+      - If the tool should be part of any pre-defined bundle, update the `help_text` of the `tools_bundle` property to include it in the relevant bundle(s).
+    - Update the list of tools in the `Tools Selection` section in the `usage.md` file.
 12. Add your tool to the table `Compatibility between tools and data type` on in the `README.md` file found in the base directory of seqinspector.
 13. Add a description of the output files and if relevant any appropriate images from the MultiQC report to `docs/output.md`.
 14. Update the metromap (can be found in `assets`) to include your new step.

--- a/docs/output.md
+++ b/docs/output.md
@@ -65,6 +65,8 @@ Fasta index with `samtools faidx`
 
 ### FQ
 
+[FQ/lint](https://github.com/stjude-rust-labs/fq) validates FASTQ files for common formatting issues such as invalid characters, inconsistent quality encodings and read name problems.
+
 <details markdown="1">
 <summary>Output files</summary>
 
@@ -75,6 +77,8 @@ Fasta index with `samtools faidx`
 
 ### CheckQC
 
+[CheckQC](https://github.com/clinical-genomics-uppsala/CheckQC) validates sequencing metrics against predefined thresholds for the given instrument and flowcell configuration.
+
 <details markdown="1">
 <summary>Output files</summary>
 
@@ -84,6 +88,8 @@ Fasta index with `samtools faidx`
 </details>
 
 ### Rundirparser
+
+[Rundirparser](https://github.com/nf-core/seqinspector) extracts run metadata from Illumina run directories by parsing the `runParameters.xml` file and generates a MultiQC-compatible YAML report.
 
 <details markdown="1">
 <summary>Output files</summary>
@@ -268,6 +274,8 @@ Aligned reads are then sorted using [samtools](#samtools) in the same process, a
 [Picard_collecthsmetrics](https://gatk.broadinstitute.org/hc/en-us/articles/360036856051-CollectHsMetrics-Picard) is a tool to collect metrics on the alignment SAM/BAM files that are specific for sequence datasets generated through hybrid-selection (mostly used to capture exon-specific sequences for targeted sequencing).
 
 ### Picard CollectMultipleMetrics
+
+[Picard CollectMultipleMetrics](https://broadinstitute.github.io/picard/) runs multiple Picard tools in a single pass to collect alignment, base distribution, quality and read length metrics from BAM files.
 
 <details markdown="1">
 <summary>Output files</summary>

--- a/docs/output.md
+++ b/docs/output.md
@@ -37,26 +37,29 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and can generat
 
 ### References
 
+The pipeline generates reference indices from a FASTA file when they are not provided via `--bwamem2`, `--fai`, or `--dict`.
+Indices are only created if the active tools require them — if no alignment-based tools (Picard, Riker) are selected, no reference indices are generated.
+
 <details markdown="1">
 <summary>Output files</summary>
 
-For a given reference fasta file, the pipeline will generate the following (if not provided):
-
-bwa-mem2 indexes with `bwa-mem2 index`.
+BWA-MEM2 index files generated with `bwa-mem2 index`.
+Required by `picard_collecthsmetrics`, `picard_collectmultiplemetrics`, and `riker`.
 
 - `references/bwamem2/`
-  - `*.fa`
   - `*.fa.amb`
   - `*.fa.ann`
   - `*.fa.bwt`
   - `*.fa.pac`
 
-Fasta dictionary with `picard CreateSequenceDictionary`
+Fasta dictionary generated with `picard CreateSequenceDictionary`.
+Required by `picard_collecthsmetrics`.
 
 - `references/`
   - `*.dict`
 
-Fasta index with `samtools faidx`
+Fasta index generated with `samtools faidx`.
+Required by `picard_collecthsmetrics`, `picard_collectmultiplemetrics`, and `riker`.
 
 - `references/`
   - `*.fa.fai`
@@ -126,6 +129,7 @@ This software is written in Python and developed by the GenomiqueENS core facili
 
 [SeqFu](https://telatin.github.io/seqfu2/) is general-purpose program to manipulate and parse information from FASTA/FASTQ files, supporting gzipped input files.
 Includes functions to interleave and de-interleave FASTQ files, to rename sequences and to count and print statistics on sequence lengths.
+
 In this pipeline, the `seqfu stats` module is used to produce general quality metrics statistics.
 
 ### BBMap Clumpify
@@ -140,11 +144,14 @@ In this pipeline, the `seqfu stats` module is used to produce general quality me
 
 </details>
 
-[BBMap Clumpify](https://jgi.doe.gov/data-and-tools/software-tools/bbtools/bb-tools-user-guide/clumpify-guide/) reorders reads for better compression and marks duplicates by appending `duplicate` to read names. The log reports duplication statistics for QC purposes.
+[BBMap Clumpify](https://jgi.doe.gov/data-and-tools/software-tools/bbtools/bb-tools-user-guide/clumpify-guide/) reorders reads for better compression and marks duplicates by appending `duplicate` to read names.
+The log reports duplication statistics for QC purposes.
 
 When `--save_bbmap_clumpify_reads` is enabled, the clumped FASTQ files are published to `bbmap/[sample_id]/`.
 
-The tool arguments can be customised via `--bbmap_clumpify_args`. By default, `markduplicates=true` is used to mark duplicates. To remove duplicates entirely, add `dedupe=true`:
+The tool arguments can be customised via `--bbmap_clumpify_args`.
+By default, `markduplicates=true` is used to mark duplicates.
+To remove duplicates entirely, add `dedupe=true`:
 
 ```bash
 --bbmap_clumpify_args 'markduplicates=true dedupe=true'
@@ -191,7 +198,8 @@ For further reading and documentation see the [FastQC help pages](http://www.bio
 
 </details>
 
-[Sequali](https://sequali.readthedocs.io/en/latest/) gives general quality metrics for short and long sequenced reads. It provides information about the quality score distribution across your reads, GC content, duplication levels, length distribution, adapter contamination (Illumina and Oxford Nanopore) and overrepresented sequences.
+[Sequali](https://sequali.readthedocs.io/en/latest/) gives general quality metrics for short and long sequenced reads.
+It provides information about the quality score distribution across your reads, GC content, duplication levels, length distribution, adapter contamination (Illumina and Oxford Nanopore) and overrepresented sequences.
 
 ### FASTQE
 
@@ -313,11 +321,15 @@ Aligned reads are then sorted using [samtools](#samtools) in the same process, a
 
 </details>
 
-[Riker](https://github.com/fulcrumgenomics/riker) is a fast Rust CLI toolkit for sequencing QC metrics. It ports key QC metrics tools from Picard with cleaner output and better performance. When `--bait_intervals` and `--target_intervals` are provided, Riker also generates hybrid capture (hybcap) metrics.
+[Riker](https://github.com/fulcrumgenomics/riker) is a fast Rust CLI toolkit for sequencing QC metrics.
+It ports key QC metrics tools from Picard with cleaner output and better performance.
+When `--bait_intervals` and `--target_intervals` are provided, Riker also generates hybrid capture (hybcap) metrics.
 
 ### Kraken2
 
-[Kraken](https://ccb.jhu.edu/software/kraken2/) is a taxonomic sequence classifier that assigns taxonomic labels to DNA sequences. Kraken examines the k-mers within a query sequence and uses the information within those k-mers to query a database. That database maps -mers to the lowest common ancestor (LCA) of all genomes known to contain a given k-mer.
+[Kraken](https://ccb.jhu.edu/software/kraken2/) is a taxonomic sequence classifier that assigns taxonomic labels to DNA sequences.
+Kraken examines the k-mers within a query sequence and uses the information within those k-mers to query a database.
+That database maps -mers to the lowest common ancestor (LCA) of all genomes known to contain a given k-mer.
 
 <details markdown="1">
 <summary>Output files</summary>
@@ -331,7 +343,8 @@ Aligned reads are then sorted using [samtools](#samtools) in the same process, a
 
 </details>
 
-The main taxonomic classification file from Kraken2 is the `*report.txt` file. It gives you the most information for a single sample.
+The main taxonomic classification file from Kraken2 is the `*report.txt` file.
+It gives you the most information for a single sample.
 You will only receive the `.fastq` and `*classifiedreads.txt` file if you supply `--kraken2_save_reads` and/or `--kraken2_save_readclassifications` parameters to the pipeline.
 
 ### Krona
@@ -348,14 +361,15 @@ Krona charts will be generated by the pipeline for supported tools (Kraken2, Cen
 
 </details>
 
-The resulting HTML files can be loaded into your web browser for exploration. Each file will have a dropdown to allow you to switch between each sample aligned against the given database of the tool.
+The resulting HTML files can be loaded into your web browser for exploration.
+Each file will have a dropdown to allow you to switch between each sample aligned against the given database of the tool.
 
 ### MultiQC
 
 nf-core/seqinspector will generate the following MultiQC reports:
 
 - one global report including all the samples listed in the samplesheet.
-- one group report per unique tag. These reports compile samples that share the same tag.
+- one group report per unique tag, these reports compile samples that share the same tag.
 
 <details markdown="1">
 <summary>Output files</summary>
@@ -397,7 +411,8 @@ The MultiQC global report might also contain metrics related to the rundir via t
 
 </details>
 
-[SeqkitStats](https://bioinf.shenwei.me/seqkit/usage/#stats) it gives simple statistics such as number of sequences, min/max_len, N50, Q20%, Q30% and GC%. For further reading and documentation see the [Seqkit help pages](https://bioinf.shenwei.me/seqkit/).
+[SeqkitStats](https://bioinf.shenwei.me/seqkit/usage/#stats) it gives simple statistics such as number of sequences, min/max_len, N50, Q20%, Q30% and GC%.
+For further reading and documentation see the [Seqkit help pages](https://bioinf.shenwei.me/seqkit/).
 
 ### Pipeline information
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -215,15 +215,7 @@ See official [nexflow](https://www.nextflow.io/docs/latest/config.html) and [nf-
 
 It is possible to also choose bundles of pre-specified tools using the `--tools_bundle` parameter. It is still possible to remove tools using the `--skip_tools` parameters or add additional tools with the `--tools` parameter when choosing a predefined setup with `--tools_bundle`.
 
-Currently, the following bundles are available:
-
-- **default**: fastqc, fastqscreen, fq_lint, picard_collectmultiplemetrics, rundirparser, seqfu_stats, sequali (requires `genome` and Illumina runfolder)
-- **all**: all available tools (requires `genome` and Illumina runfolder)
-- **minimal**: fastqc, fastqscreen, picard_collectmultiplemetrics, seqfu_stats (requires `genome`)
-- **bam**: picard_collecthsmetrics, picard_collectmultiplemetrics, riker (requires `genome`)
-- **fastq**: fastqc, fastqscreen, fq_lint, seqkit_stats
-- **illumina**: checkqc, multiqcsav, rundirparser, seqfu_stats (requires Illumina runfolder)
-- **ont**: fastqc, fastqscreen, seqkit_stats, sequali, toulligqc
+See the [parameters page](https://nf-co.re/seqinspector/dev/parameters/#tools) for the list of available bundles and their contents.
 
 ### Available functionality and tools
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -165,7 +165,9 @@ Or to disable subsampling for all tools (run everything on original data):
 nextflow run nf-core/seqinspector --input ./samplesheet.csv --outdir ./results --sample_size 1000000 --subsample_tools null
 ```
 
-Note: `picard_collecthsmetrics` and `picard_collectmultiplemetrics` share the same alignment step. Selecting one for subsampling will automatically subsample the other as well.
+:::note
+`picard_collecthsmetrics` and `picard_collectmultiplemetrics` share the same alignment step. Selecting one for subsampling will automatically subsample the other as well.
+:::
 
 Note: The `--subsample_tools` parameter only takes effect when `sample_size > 0`.
 
@@ -173,7 +175,7 @@ Note: The `--subsample_tools` parameter only takes effect when `sample_size > 0`
 
 Tools selection is an integral part of sequinspector and, as the pipeline grows, it will become more and more important to select tools of interest.
 By **default**, the pipeline does run a subsection of tools as defined in the `utils_nfcore_seqinspector_pipeline` subworkflow.
-Currently, the following tools are run as default:
+Currently, the following tools are run by default:
 
 - fastqc
 - fastqscreen
@@ -200,151 +202,35 @@ Currently the `tools` param can have the following values: bbmap_clumpify, check
 
 #### Skip specific tools
 
-Some tools might not be compatible with your data or you do not require all tools that are going to be run. In this case you can skip them by providing a comma-separated list of tools to be skipped with the `--skip_tools` parameter.
+Some tools might not be compatible with your data or you do not require all tools that are going to be run. In this case you can skip them by providing a comma-separated list of tools to be skipped with the `--skip_tools` parameter, e.g.:
+
+```bash
+--skip_tools fastqe,kraken2,riker
+```
 
 The nextflow configuration file can also be use to customise tool arguments.
 See official [nexflow](https://www.nextflow.io/docs/latest/config.html) and [nf-core](https://nf-co.re/docs/usage/configuration#customising-tool-arguments) documentation for further details.
 
-#### Custom tool arguments
-
-Some tools accept additional arguments that can be customised via command-line parameters. The following tool arguments are available:
-
-| Parameter               | Default                           | Description                                                                                              |
-| ----------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `--bbmap_clumpify_args` | `"markduplicates=true"`           | Arguments passed to BBMap Clumpify. Use `dedupe=true` to remove duplicates instead of just marking them. |
-| `--fq_lint_args`        | `""`                              | Arguments passed to fq-lint.                                                                             |
-| `--riker_args`          | `"--tools alignment basic isize"` | Arguments passed to riker multi. Use `--tools` to select which collectors to run.                        |
-
 #### Choose pre-defined bundles of tools
 
-It is possible to also chose bundles of pre-specified tools using the `tools_bundle` parameter. It is still possible to remove tools using the `skip_tools` parameters or add additional tools with the `tools` parameter when chosing a predefined setup with `tools_bundle`.
+It is possible to also choose bundles of pre-specified tools using the `--tools_bundle` parameter. It is still possible to remove tools using the `--skip_tools` parameters or add additional tools with the `--tools` parameter when choosing a predefined setup with `--tools_bundle`.
 
 Currently, the following bundles are available:
 
-<details>
-<summary>default</summary>
-
-Requirements:
-
-- specification of the `genome` parameter
-- specification of the Illumina runfolder
-
-Tools:
-
-- fastqc
-- fastqscreen
-- fq_lint
-- picard_collectmultiplemetrics
-- rundirparser
-- seqfu_stats
-- sequali
-
-</details>
-
-<details>
-<summary>all</summary>
-
-Requirements:
-
-- specification of the `genome` parameter
-- specification of the Illumina runfolder
-
-Tools:
-
-- bbmap_clumpify
-- checkqc
-- fastqc
-- fastqe
-- fastqscreen
-- fq_lint
-- multiqcsav
-- picard_collecthsmetrics
-- picard_collectmultiplemetrics
-- riker
-- rundirparser
-- seqkit_stats
-- seqfu_stats
-- sequali
-- toulligqc
-
-</details>
-
-<details>
-<summary>minimal</summary>
-
-Requirements:
-
-- specification of the `genome` parameter
-
-Tools:
-
-- fastqc
-- fastqscreen
-- picard_collectmultiplemetrics
-- seqfu_stats
-</details>
-
-<details>
-<summary>bam</summary>
-
-Requirements:
-
-- specification of the `genome` parameter
-
-Tools:
-
-- picard_collecthsmetrics
-- picard_collectmultiplemetrics
-- riker
-
-</details>
-
-<details>
-<summary>fastq</summary>
-
-Tools:
-
-- fastqc
-- fastqscreen
-- fq_lint
-- seqkit_stats
-
-</details>
-
-<details>
-<summary>illumina</summary>
-
-Requirements:
-
-- Specification of the Illumina runfolder
-
-Tools:
-
-- checkqc
-- multiqcsav
-- rundirparser
-- seqfu_stats
-</details>
-
-<details>
-<summary>ont</summary>
-
-Tools:
-
-- fastqc
-- fastqscreen
-- seqkit_stats
-- sequali
-- toulligqc
-
-</details>
+- **default**: fastqc, fastqscreen, fq_lint, picard_collectmultiplemetrics, rundirparser, seqfu_stats, sequali (requires `genome` and Illumina runfolder)
+- **all**: all available tools (requires `genome` and Illumina runfolder)
+- **minimal**: fastqc, fastqscreen, picard_collectmultiplemetrics, seqfu_stats (requires `genome`)
+- **bam**: picard_collecthsmetrics, picard_collectmultiplemetrics, riker (requires `genome`)
+- **fastq**: fastqc, fastqscreen, fq_lint, seqkit_stats
+- **illumina**: checkqc, multiqcsav, rundirparser, seqfu_stats (requires Illumina runfolder)
+- **ont**: fastqc, fastqscreen, seqkit_stats, sequali, toulligqc
 
 ### Available functionality and tools
 
 #### BWAMEM2 and alignment-based QC tools
 
 If no genome or fasta file is provided, either with `--genome` or `--fasta`,
-the pipeline will not be able to run the alignment step with BWAMEM2,
+the pipeline will not be able to run the alignment step with `BWAMEM2`,
 and will skip all tools that depend on the alignment file (e.g. `picard CollectHsMetrics` and `picard CollectMultipleMetrics`).
 
 #### Hybrid-selection QC metrics

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -215,7 +215,7 @@ See official [nexflow](https://www.nextflow.io/docs/latest/config.html) and [nf-
 
 It is possible to also choose bundles of pre-specified tools using the `--tools_bundle` parameter. It is still possible to remove tools using the `--skip_tools` parameters or add additional tools with the `--tools` parameter when choosing a predefined setup with `--tools_bundle`.
 
-See the [parameters page](https://nf-co.re/seqinspector/dev/parameters/#tools) for the list of available bundles and their contents.
+See the [parameters page](https://nf-co.re/seqinspector/dev/parameters/#tools_bundle) for the list of available bundles and their contents.
 
 ### Available functionality and tools
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -58,6 +58,7 @@
                 "tools_bundle": {
                     "type": "string",
                     "description": "Select some default setup for the tools to be run, tools can still be used to add tools",
+                    "help_text": "Pre-defined bundles of tools. Available bundles:\n- `default`: fastqc, fastqscreen, fq_lint, picard_collectmultiplemetrics, rundirparser, seqfu_stats, sequali (requires `genome` and Illumina runfolder)\n- `all`: all available tools (requires `genome` and Illumina runfolder)\n- `minimal`: fastqc, fastqscreen, picard_collectmultiplemetrics, seqfu_stats (requires `genome`)\n- `bam`: picard_collecthsmetrics, picard_collectmultiplemetrics, riker (requires `genome`)\n- `fastq`: fastqc, fastqscreen, fq_lint, seqkit_stats\n- `illumina`: checkqc, multiqcsav, rundirparser, seqfu_stats (requires Illumina runfolder)\n- `ont`: fastqc, fastqscreen, seqkit_stats, sequali, toulligqc\n- `null`: disables all bundles, use with `--tools` to select individual tools",
                     "pattern": "^((all|bam|fastq|default|illumina|minimal|ont|null)?,?)*(?<!,)$",
                     "fa_icon": "fas fa-window-restore",
                     "default": "default"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -121,7 +121,7 @@
                     "default": "markduplicates=true",
                     "fa_icon": "fas fa-cog",
                     "description": "Arguments to pass to BBMap Clumpify",
-                    "help_text": "Arguments to pass to BBMap Clumpify. Defaults to `markduplicates=true`."
+                    "help_text": "Arguments to pass to BBMap Clumpify. Defaults to `markduplicates=true` to mark duplicates. Use `dedupe=true` to remove duplicates entirely instead of just marking them."
                 }
             }
         },


### PR DESCRIPTION
Address all review comments from #251:

- Add tool descriptions to empty headings in output.md (FQ, CheckQC, Rundirparser, Picard CollectMultipleMetrics)
- Wrap shared alignment note in :::note admonition
- Fix phrasing ("run as default" → "run by default")
- Remove duplicated custom tool arguments table from usage.md
- Add skip_tools example
- Fix --tools_bundle text and typo ("chosing" → "choosing")
- Replace verbose tool bundle details with compact list
- Wrap BWAMEM2 in backticks

Note: riker_args left as free-form string since other arguments beyond --tools are also likely.

---

*Generated via [opencode](https://opencode.ai)*
Verified by @maxulysse 