### PR TITLE
Add validation for missing bait/target intervals with picard_collecthsmetrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- [#280](https://github.com/nf-core/seqinspector/pull/280) Add validation for missing `--bait_intervals` and `--target_intervals` when `picard_collecthsmetrics` is requested (@maxulysse)
+
 ### `Fixed`
 
 ### `Changed`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 - [#280](https://github.com/nf-core/seqinspector/pull/280) Add validation for missing `--bait_intervals` and `--target_intervals` when `picard_collecthsmetrics` is requested (@maxulysse)
+- [#280](https://github.com/nf-core/seqinspector/pull/280) Add validation for missing fasta when picard or riker is requested (@maxulysse)
+- [#280](https://github.com/nf-core/seqinspector/pull/280) Add validation for unsupported riker collectors (wgs, gcbias, error, rna) that require interval files not yet supported as pipeline parameters (@maxulysse)
 
 ### `Fixed`
 

--- a/subworkflows/local/utils_nfcore_seqinspector_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_seqinspector_pipeline/main.nf
@@ -167,8 +167,7 @@ ${subsampled_info}-\033[2m----------------------------------------------------\0
         }
 
     if (!(fasta) && (("picard_collecthsmetrics" in tools) || ("picard_collectmultiplemetrics" in tools) || ("riker" in tools))) {
-        log.warn("No fasta was provided, but picard or riker was requested")
-        log.warn("BWAMEM2, SAMTOOLS, PICARD and RIKER processes will be skipped")
+        error("No fasta was provided, but picard or riker was requested. A reference FASTA is required for these tools.")
     }
 
     if ('picard_collecthsmetrics' in tools && (!params.bait_intervals || !params.target_intervals)) {
@@ -242,6 +241,7 @@ workflow PIPELINE_COMPLETION {
 def validateInputParameters(tools, riker_args) {
     genomeExistsError()
     rikerHybcapError(tools, riker_args)
+    rikerUnsupportedCollectorsError(tools, riker_args)
 }
 
 //
@@ -275,6 +275,23 @@ def genomeExistsError() {
 def rikerHybcapError(tools, riker_args) {
     if ('riker' in tools && riker_args?.contains('hybcap') && (!params.bait_intervals || !params.target_intervals)) {
         error("riker_args contains 'hybcap' but --bait_intervals and --target_intervals were not provided. Both are required for hybcap metrics.")
+    }
+}
+
+//
+// Exit pipeline if riker collectors requiring interval files are requested
+// but the pipeline does not yet support providing those files
+//
+def rikerUnsupportedCollectorsError(tools, riker_args) {
+    if ('riker' in tools && riker_args) {
+        def unsupported = []
+        if (riker_args.contains('wgs'))       unsupported << 'wgs (requires --wgs_intervals)'
+        if (riker_args.contains('gcbias'))    unsupported << 'gcbias (requires --gcbias_exclude_intervals)'
+        if (riker_args.contains('error'))     unsupported << 'error (requires --error_vcf and/or --error_intervals)'
+        if (riker_args.contains('rna'))       unsupported << 'rna (requires --rna_gene_model and/or --rna_ribosomal_intervals)'
+        if (unsupported) {
+            error("riker_args contains collectors that require interval files not yet supported as pipeline parameters: ${unsupported.join(', ')}.")
+        }
     }
 }
 

--- a/subworkflows/local/utils_nfcore_seqinspector_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_seqinspector_pipeline/main.nf
@@ -171,6 +171,10 @@ ${subsampled_info}-\033[2m----------------------------------------------------\0
         log.warn("BWAMEM2, SAMTOOLS, PICARD and RIKER processes will be skipped")
     }
 
+    if ('picard_collecthsmetrics' in tools && (!params.bait_intervals || !params.target_intervals)) {
+        error("picard_collecthsmetrics was requested but --bait_intervals and --target_intervals were not provided. Both are required for CollectHsMetrics.")
+    }
+
     if ('toulligqc' in tools && 'emulate_amd64' in workflow.profile.tokenize(",")) {
         error("ToulligQC is not compatible with the 'emulate_amd64' profile. Please remove ToulligQC from the list of tools if you wish to run seqinspector on this architecture.")
     }

--- a/subworkflows/local/utils_nfcore_seqinspector_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_seqinspector_pipeline/main.nf
@@ -166,10 +166,12 @@ ${subsampled_info}-\033[2m----------------------------------------------------\0
             }
         }
 
+    // Picard and riker require a reference FASTA for alignment and metrics
     if (!(fasta) && (("picard_collecthsmetrics" in tools) || ("picard_collectmultiplemetrics" in tools) || ("riker" in tools))) {
         error("No fasta was provided, but picard or riker was requested. A reference FASTA is required for these tools.")
     }
 
+    // CollectHsMetrics requires bait and target interval lists
     if ('picard_collecthsmetrics' in tools && (!params.bait_intervals || !params.target_intervals)) {
         error("picard_collecthsmetrics was requested but --bait_intervals and --target_intervals were not provided. Both are required for CollectHsMetrics.")
     }

--- a/tests/no_genome.nf.test
+++ b/tests/no_genome.nf.test
@@ -11,7 +11,7 @@ nextflow_pipeline {
             params: [
                 input: pipelines_testdata_base_path + 'seqinspector/samplesheet/1.0/miseq.csv',
                 genome: null,
-                tools: 'fastqscreen,picard_collecthsmetrics',
+                tools: 'fastqscreen',
                 tools_bundle: null,
             ],
         ],
@@ -20,7 +20,7 @@ nextflow_pipeline {
             params: [
                 input: pipelines_testdata_base_path + 'seqinspector/samplesheet/1.0/miseq.csv',
                 genome: null,
-                tools: 'fastqscreen,picard_collecthsmetrics',
+                tools: 'fastqscreen',
                 tools_bundle: null,
             ],
             stub: true,

--- a/tests/no_genome.nf.test.snap
+++ b/tests/no_genome.nf.test.snap
@@ -1,4 +1,22 @@
 {
+    "MiSeq data test - no genome with picard - should fail": {
+        "content": [
+            [
+                "pipeline_info"
+            ],
+            "No stable content",
+            "No BAM files",
+            "No warnings",
+            [
+                "[ERROR] No fasta was provided, but picard or riker was requested. A reference FASTA is required for these tools."
+            ]
+        ],
+        "timestamp": "2026-08-20T13:38:47.440297992",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
     "MiSeq data test - no genome": {
         "content": [
             6,
@@ -188,6 +206,24 @@
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"
+        }
+    },
+    "MiSeq data test - no genome with picard - stub": {
+        "content": [
+            [
+                "pipeline_info"
+            ],
+            [
+                "[WARN] WARN: nf-core pipelines do not accept positional arguments. The positional argument `true` has been detected. HINT: A common mistake is to provide multiple values separated by spaces e.g. `-profile test, [CONTAINER]`."
+            ],
+            [
+                "[ERROR] No fasta was provided, but picard or riker was requested. A reference FASTA is required for these tools."
+            ]
+        ],
+        "timestamp": "2026-08-20T13:39:11.195831371",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/tests/tools_picard.nf.test
+++ b/tests/tools_picard.nf.test
@@ -26,6 +26,27 @@ nextflow_pipeline {
             ],
             stub: true,
         ],
+        [
+            name: "NovaSeq6000 data test - picard_collecthsmetrics missing intervals - should fail",
+            params: [
+                tools: 'picard_collecthsmetrics',
+                tools_bundle: null,
+            ],
+            failure: true,
+            snapshot_include: 'bait_intervals',
+            snapshot: 'stdout,stderr',
+        ],
+        [
+            name: "NovaSeq6000 data test - picard_collecthsmetrics missing intervals - stub",
+            params: [
+                tools: 'picard_collecthsmetrics',
+                tools_bundle: null,
+            ],
+            failure: true,
+            stub: true,
+            snapshot_include: 'bait_intervals',
+            snapshot: 'stdout,stderr',
+        ],
     ]
 
     // Generate tests for each scenario

--- a/tests/tools_picard.nf.test
+++ b/tests/tools_picard.nf.test
@@ -47,6 +47,29 @@ nextflow_pipeline {
             snapshot_include: 'bait_intervals',
             snapshot: 'stdout,stderr',
         ],
+        [
+            name: "NovaSeq6000 data test - picard missing fasta - should fail",
+            params: [
+                tools: 'picard_collecthsmetrics,picard_collectmultiplemetrics',
+                tools_bundle: null,
+                genome: null,
+            ],
+            failure: true,
+            snapshot_include: 'fasta',
+            snapshot: 'stdout,stderr',
+        ],
+        [
+            name: "NovaSeq6000 data test - picard missing fasta - stub",
+            params: [
+                tools: 'picard_collecthsmetrics,picard_collectmultiplemetrics',
+                tools_bundle: null,
+                genome: null,
+            ],
+            failure: true,
+            stub: true,
+            snapshot_include: 'fasta',
+            snapshot: 'stdout,stderr',
+        ],
     ]
 
     // Generate tests for each scenario

--- a/tests/tools_picard.nf.test.snap
+++ b/tests/tools_picard.nf.test.snap
@@ -1,4 +1,22 @@
 {
+    "NovaSeq6000 data test - picard_collecthsmetrics missing intervals - should fail": {
+        "content": [
+            [
+                "pipeline_info"
+            ],
+            "No stable content",
+            "No BAM files",
+            "No warnings",
+            [
+                "[ERROR] picard_collecthsmetrics was requested but --bait_intervals and --target_intervals were not provided. Both are required for CollectHsMetrics."
+            ]
+        ],
+        "timestamp": "2026-08-20T11:25:23.275081727",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
     "NovaSeq6000 data test - picard_collecthsmetrics and picard_collectmultiplemetrics": {
         "content": [
             28,
@@ -692,6 +710,24 @@
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"
+        }
+    },
+    "NovaSeq6000 data test - picard_collecthsmetrics missing intervals - stub": {
+        "content": [
+            [
+                "pipeline_info"
+            ],
+            [
+                "[WARN] WARN: nf-core pipelines do not accept positional arguments. The positional argument `true` has been detected. HINT: A common mistake is to provide multiple values separated by spaces e.g. `-profile test, [CONTAINER]`."
+            ],
+            [
+                "[ERROR] picard_collecthsmetrics was requested but --bait_intervals and --target_intervals were not provided. Both are required for CollectHsMetrics."
+            ]
+        ],
+        "timestamp": "2026-08-20T11:25:48.76823048",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/tests/tools_picard.nf.test.snap
+++ b/tests/tools_picard.nf.test.snap
@@ -1,4 +1,22 @@
 {
+    "NovaSeq6000 data test - picard missing fasta - stub": {
+        "content": [
+            [
+                "pipeline_info"
+            ],
+            [
+                "[WARN] WARN: nf-core pipelines do not accept positional arguments. The positional argument `true` has been detected. HINT: A common mistake is to provide multiple values separated by spaces e.g. `-profile test, [CONTAINER]`."
+            ],
+            [
+                "[ERROR] No fasta was provided, but picard or riker was requested. A reference FASTA is required for these tools."
+            ]
+        ],
+        "timestamp": "2026-08-20T13:42:47.524968852",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
     "NovaSeq6000 data test - picard_collecthsmetrics missing intervals - should fail": {
         "content": [
             [
@@ -710,6 +728,24 @@
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"
+        }
+    },
+    "NovaSeq6000 data test - picard missing fasta - should fail": {
+        "content": [
+            [
+                "pipeline_info"
+            ],
+            "No stable content",
+            "No BAM files",
+            "No warnings",
+            [
+                "[ERROR] No fasta was provided, but picard or riker was requested. A reference FASTA is required for these tools."
+            ]
+        ],
+        "timestamp": "2026-08-20T13:42:28.564703052",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     },
     "NovaSeq6000 data test - picard_collecthsmetrics missing intervals - stub": {

--- a/tests/tools_riker.nf.test
+++ b/tests/tools_riker.nf.test
@@ -54,6 +54,50 @@ nextflow_pipeline {
             snapshot_include: 'hybcap',
             snapshot: 'stdout,stderr',
         ],
+        [
+            name: "NovaSeq6000 data test - riker with wgs collector - should fail",
+            params: [
+                tools: 'riker',
+                tools_bundle: null,
+                riker_args: '--tools wgs',
+            ],
+            failure: true,
+            snapshot_include: 'wgs',
+            snapshot: 'stdout,stderr',
+        ],
+        [
+            name: "NovaSeq6000 data test - riker with gcbias collector - should fail",
+            params: [
+                tools: 'riker',
+                tools_bundle: null,
+                riker_args: '--tools gcbias',
+            ],
+            failure: true,
+            snapshot_include: 'gcbias',
+            snapshot: 'stdout,stderr',
+        ],
+        [
+            name: "NovaSeq6000 data test - riker with error collector - should fail",
+            params: [
+                tools: 'riker',
+                tools_bundle: null,
+                riker_args: '--tools error',
+            ],
+            failure: true,
+            snapshot_include: 'error',
+            snapshot: 'stdout,stderr',
+        ],
+        [
+            name: "NovaSeq6000 data test - riker with rna collector - should fail",
+            params: [
+                tools: 'riker',
+                tools_bundle: null,
+                riker_args: '--tools rna',
+            ],
+            failure: true,
+            snapshot_include: 'rna',
+            snapshot: 'stdout,stderr',
+        ],
     ]
 
     // Generate tests for each scenario

--- a/tests/tools_riker.nf.test.snap
+++ b/tests/tools_riker.nf.test.snap
@@ -688,6 +688,25 @@
             "nextflow": "26.04.4"
         }
     },
+    "NovaSeq6000 data test - riker with error collector - should fail": {
+        "content": [
+            [
+                "pipeline_info"
+            ],
+            "No stable content",
+            "No BAM files",
+            "No warnings",
+            [
+                "  riker_args                : --tools error",
+                "[ERROR] riker_args contains collectors that require interval files not yet supported as pipeline parameters: error (requires --error_vcf and/or --error_intervals)."
+            ]
+        ],
+        "timestamp": "2026-08-20T13:45:32.710635876",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
     "NovaSeq6000 data test - riker": {
         "content": [
             22,
@@ -1199,10 +1218,10 @@
             "No warnings",
             [
                 "  riker_args                : --tools alignment basic hybcap isize",
-                "riker_args contains 'hybcap' but --bait_intervals and --target_intervals were not provided. Both are required for hybcap metrics."
+                "[ERROR] riker_args contains 'hybcap' but --bait_intervals and --target_intervals were not provided. Both are required for hybcap metrics."
             ]
         ],
-        "timestamp": "2026-08-18T17:15:06.896364673",
+        "timestamp": "2026-08-20T13:44:58.086282217",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -1384,6 +1403,63 @@
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"
+        }
+    },
+    "NovaSeq6000 data test - riker with wgs collector - should fail": {
+        "content": [
+            [
+                "pipeline_info"
+            ],
+            "No stable content",
+            "No BAM files",
+            "No warnings",
+            [
+                "  riker_args                : --tools wgs",
+                "[ERROR] riker_args contains collectors that require interval files not yet supported as pipeline parameters: wgs (requires --wgs_intervals)."
+            ]
+        ],
+        "timestamp": "2026-08-20T13:45:09.799423304",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "NovaSeq6000 data test - riker with rna collector - should fail": {
+        "content": [
+            [
+                "pipeline_info"
+            ],
+            "No stable content",
+            "No BAM files",
+            "No warnings",
+            [
+                "  riker_args                : --tools rna",
+                "[ERROR] riker_args contains collectors that require interval files not yet supported as pipeline parameters: rna (requires --rna_gene_model and/or --rna_ribosomal_intervals)."
+            ]
+        ],
+        "timestamp": "2026-08-20T13:45:46.820741616",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "NovaSeq6000 data test - riker with gcbias collector - should fail": {
+        "content": [
+            [
+                "pipeline_info"
+            ],
+            "No stable content",
+            "No BAM files",
+            "No warnings",
+            [
+                "  riker_args                : --tools gcbias",
+                "[ERROR] riker_args contains collectors that require interval files not yet supported as pipeline parameters: gcbias (requires --gcbias_exclude_intervals)."
+            ]
+        ],
+        "timestamp": "2026-08-20T13:45:21.058527183",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     }
 }


### PR DESCRIPTION
Add validation that fails fast with a clear error message when `picard_collecthsmetrics` is requested but `--bait_intervals` and/or `--target_intervals` are not provided.

Changes:
- Added `error()` in `PIPELINE_INITIALISATION` subworkflow for missing intervals
- Added 2 test cases (regular + stub) to `tests/tools_picard.nf.test` verifying the validation

Generated by opencode
Verified by @maxulysse